### PR TITLE
Add boot_type to ServerDefinition

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -670,6 +670,9 @@ type ScalewayServerDefinition struct {
 	// DynamicIPRequired is a flag that defines a server with a dynamic ip address attached
 	DynamicIPRequired *bool `json:"dynamic_ip_required,omitempty"`
 
+	// BootType defines the type of boot
+	BootType string `json:"boot_type,omitempty"`
+
 	// Bootscript is the bootscript used by the server
 	Bootscript *string `json:"bootscript"`
 


### PR DESCRIPTION
Allows user to select boot_type on server creation

Resolves #2 , maybe more modifications needed?

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>