### PR TITLE
Update location of fuzzysearch package

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/lithammer/fuzzysearch/fuzzy"
 	"github.com/moul/anonuuid"
-	"github.com/renstrom/fuzzysearch/fuzzy"
 	"github.com/scaleway/go-scaleway/types"
 )
 


### PR DESCRIPTION
`github.com/renstrom/fuzzysearch` has been [moved](https://github.com/lithammer/fuzzysearch/commit/2b3868bbed94cd7434028ca3f47b0366a822e0b0) to `github.com/lithammer/fuzzysearch`.