### PR TITLE
Fix fuzzysearch dependecy after repo path change

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/lithammer/fuzzysearch/fuzzy"
 	"github.com/moul/anonuuid"
-	"github.com/renstrom/fuzzysearch/fuzzy"
 	"github.com/scaleway/go-scaleway/types"
 )
 


### PR DESCRIPTION
Fix broken dependency: renstrom was renamed to lithammer breaking imports performed by `go mod`

```
go: github.com/renstrom/fuzzysearch@v1.0.2: parsing go.mod: unexpected module path "github.com/lithammer/fuzzysearch"
```